### PR TITLE
Adding SUBPATH support

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,8 @@ Specification of rclone parameters on a per remote basis can be created inside h
 
         PROFILE=0
 
+        SUBPATH= ( root directory of share )
+
    **NOTE:** _The above are defaults for all remotes without `.*.param` files containing opposing values. 
 
 - Custom remote params example #1
@@ -117,6 +119,18 @@ Specification of rclone parameters on a per remote basis can be created inside h
          5| 
 
     **NOTE:** _There is no need to specify values you do not wish to change. Ensure a line break/carriage return exist after each specified param or they will not be parsed. For more information see [issue #2](https://github.com/Magisk-Modules-Repo/com.piyushgarg.rclone/issues/2)_
+
+- Custom remote params example #2 (using SUBPATH)
+
+   _The following configuration will mount the remote subdirectory `Batman` as the root directory of the share `[Movies]`._
+
+         /sdcard/.rclone/.Movies.param
+
+         1| SDBINDPOINT=BatmanMovie
+         2| SUBPATH=Batman
+         3| 
+
+   Now the mounted directory `/sdcard/BatmanMovie` is actually the remote directory `Movies/Batman`.
 
 ---
 ## Custom Globals

--- a/common/service.sh
+++ b/common/service.sh
@@ -107,7 +107,7 @@ custom_params () {
 
     else
 
-        PARAMS="DISABLE LOGFILE LOGLEVEL CACHEMODE CHUNKSIZE CHUNKTOTAL CACHEWORKERS CACHEINFOAGE DIRCACHETIME ATTRTIMEOUT BUFFERSIZE READAHEAD M_UID M_GID DIRPERMS FILEPERMS READONLY BINDSD SDBINDPOINT ADD_PARAMS REPLACE_PARAMS PROFILE ISOLATE SDSYNCDIRS SYNC_WIFI SYNC_BATTLVL SYNC_CHARGE"
+        PARAMS="DISABLE LOGFILE LOGLEVEL CACHEMODE CHUNKSIZE CHUNKTOTAL CACHEWORKERS CACHEINFOAGE DIRCACHETIME ATTRTIMEOUT BUFFERSIZE READAHEAD M_UID M_GID DIRPERMS FILEPERMS READONLY BINDSD SDBINDPOINT ADD_PARAMS REPLACE_PARAMS PROFILE ISOLATE SDSYNCDIRS SYNC_WIFI SYNC_BATTLVL SYNC_CHARGE SUBPATH"
     fi
 
     BAD_SYNTAX="(^\s*#|^\s*$|^\s*[a-z_][^[:space:]]*=[^;&\(\`]*$)"
@@ -120,6 +120,7 @@ custom_params () {
 
             echo "loading .${remote}.param"
 
+            # FIX: Unnecessary and very inefficient double loop
             for PARAM in ${PARAMS[@]}; do
 
                 while read -r VAR; do
@@ -130,6 +131,8 @@ custom_params () {
 
                         VALUE=\"${VALUE}\"
 
+                        # Unnecessary echo in a subshell execution below? Why not just: 
+                        # eval "${PARAM}""=""${VALUE}"
                         eval $(echo "${PARAM}""=""${VALUE}")
 
                     fi
@@ -333,6 +336,7 @@ reset_params () {
     unset SYNCDIR
     unset SDSYNCDIRS
     unset PIDFILE
+    unset SUBPATH
     LOGFILE=${USER_CONFDIR}/rclone.log
     LOGLEVEL=NOTICE
     CACHEMODE=off
@@ -406,7 +410,7 @@ rclone_mount () {
 
     mkdir -p ${CLOUDROOTMOUNTPOINT}/${remote}
 
-su -M -p -c nice -n 19 ionice -c 2 -n 7 ${HOME}/rclone mount ${remote}: ${CLOUDROOTMOUNTPOINT}/${remote} --config ${CONFIGFILE} ${RCLONE_PARAMS} --daemon >> /dev/null 2>&1 &
+su -M -p -c nice -n 19 ionice -c 2 -n 7 ${HOME}/rclone mount ${remote}:${SUBPATH} ${CLOUDROOTMOUNTPOINT}/${remote} --config ${CONFIGFILE} ${RCLONE_PARAMS} --daemon >> /dev/null 2>&1 &
 
 }
 

--- a/common/service.sh
+++ b/common/service.sh
@@ -430,7 +430,7 @@ rclone_mount () {
 
     mkdir -p ${CLOUDROOTMOUNTPOINT}/${remote}
 
-su -M -p -c nice -n 19 ionice -c 2 -n 7 ${HOME}/rclone mount ${remote}:${SUBPATH} ${CLOUDROOTMOUNTPOINT}/${remote} --config ${CONFIGFILE} ${RCLONE_PARAMS} --daemon >> /dev/null 2>&1 &
+    su -M -p -c nice -n 19 ionice -c 2 -n 7 ${HOME}/rclone mount "${remote}:${SUBPATH}" ${CLOUDROOTMOUNTPOINT}/${remote} --config ${CONFIGFILE} ${RCLONE_PARAMS} --daemon >> /dev/null 2>&1 &
 
 }
 


### PR DESCRIPTION
This simple change allows the user to specify a subdirectory to mount instead of defaulting to the root directory. Tested on a Pixel 4 XL running Android 10.