### PR TITLE
Various fixes

### DIFF
--- a/binary/rclone-wrapper.sh
+++ b/binary/rclone-wrapper.sh
@@ -1,6 +1,6 @@
 #!/system/bin/sh
 
-MODDIR=${0%/*}
+MODDIR="$(dirname -- "$(readlink -f -- "$0")")"
 UPDDIR=/data/adb/modules_update
 IMGDIR=/sbin/.core/img
 id=com.piyushgarg.rclone

--- a/common/service.sh
+++ b/common/service.sh
@@ -445,6 +445,16 @@ if [[ -e ${USER_CONFDIR}/.disable ]] && [[ ${INTERACTIVE} = 0 ]]; then
 
 fi
 
+if [[ ${INTERACTIVE} = 0 ]]; then 
+
+    export INTERACTIVE=1
+    
+    ${HOME}/service.sh
+    
+    exit
+
+fi
+
 global_params
 
 if [[ ! -d ${CLOUDROOTMOUNTPOINT} ]]; then


### PR DESCRIPTION
- Fix for deadlock in #55 

- Reload script in non-interactive mode, as `custom_params` stucks on OxygenOS 10 after boot, maybe related to data encryption.